### PR TITLE
Fix/set reference

### DIFF
--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -31,8 +31,8 @@ export class ExpandableText extends PureComponent<Props, State>
 		numberOfLines: 0,
 	}
 
-	private _text?: Text
-	private _isMounted: boolean = false
+	private text?: Text
+	private isTextMounted: boolean = false
 
 	constructor(props: Props) {
 		super(props)
@@ -65,12 +65,12 @@ export class ExpandableText extends PureComponent<Props, State>
 	}
 
 	public componentDidMount(): void {
-		this._isMounted = true
+		this.isTextMounted = true
 		this.setUpMeasurement()
 	}
 
 	public componentWillUnmount(): void {
-		this._isMounted = false
+		this.isTextMounted = false
 	}
 
 	public render(): React.ReactNode {
@@ -82,17 +82,17 @@ export class ExpandableText extends PureComponent<Props, State>
 	}
 
 	private setUpMeasurement = async (): Promise<void> => {
-		if (!this._text) throw Error('Text is not set to be measured')
+		if (!this.text) throw Error('Text is not set to be measured')
 		const { numberOfLines } = this.props
 		await nextFrameAsync();
 
-		if (!this._isMounted) return
-		this.maxHeight = await measureHeight(this._text)
+		if (!this.isTextMounted) return
+		this.maxHeight = await measureHeight(this.text)
 		this.setState({ numberOfLines })
 		await nextFrameAsync()
 
-		if (!this._isMounted) return
-		this.collapsedHeight = await measureHeight(this._text)
+		if (!this.isTextMounted) return
+		this.collapsedHeight = await measureHeight(this.text)
 
 		const isCollapsible: boolean = this.maxHeight > this.collapsedHeight
 		this.setState({
@@ -101,5 +101,5 @@ export class ExpandableText extends PureComponent<Props, State>
 		})
 	}
 
-	private setText = (ref: Text) => (this._text = ref)
+	private setText = (ref: Text) => (this.text = ref)
 }

--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -13,7 +13,7 @@ interface ExpandableTextInterface {
 interface Props {
 	numberOfLines: number
 	children: string | Text
-	ref?: (ref: ExpandableTextInterface) => void
+	controller?: (ref: ExpandableTextInterface) => void
 	onReady?: (prop: { isCollapsible: boolean }) => void
 }
 
@@ -37,7 +37,7 @@ export class ExpandableText extends PureComponent<Props, State>
 	constructor(props: Props) {
 		super(props)
 
-		if (props.ref) props.ref(this)
+		if (props.controller) props.controller(this)
 	}
 
 	public collapse = (): void => {

--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -95,10 +95,13 @@ export class ExpandableText extends PureComponent<Props, State>
 		this.collapsedHeight = await measureHeight(this.text)
 
 		const isCollapsible: boolean = this.maxHeight > this.collapsedHeight
-		this.setState({
-			isCollapsible,
-			numberOfLines: isCollapsible ? numberOfLines : 0,
-		})
+		this.setState(
+			{
+				isCollapsible,
+				numberOfLines: isCollapsible ? numberOfLines : 0,
+			},
+			() => this.props.onReady && this.props.onReady({ isCollapsible }),
+		)
 	}
 
 	private setText = (ref: Text) => (this.text = ref)


### PR DESCRIPTION
`ref()` is a React reserved method, so it wasn't being used as expected.
Having a different name it might not be quite as intuitive, but it also
allow us to have more freedom over what can be done with it.
