### PR TITLE
Re-measure on change

### DIFF
--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -1,6 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { PureComponent, ReactNode } from 'react'
 import { Text } from 'react-native'
-import { measureHeight, nextFrameAsync } from './utils'
+import {
+	extractTextFromReactNode,
+	measureHeight,
+	nextFrameAsync,
+} from './utils'
 
 interface ExpandableTextInterface {
 	collapse(): void
@@ -70,10 +74,11 @@ export class ExpandableText extends PureComponent<Props, State>
 	}
 
 	public componentDidUpdate(prevProps: Readonly<Props>): void {
+		const oldText = extractTextFromReactNode(prevProps.children)
+		const newText = extractTextFromReactNode(this.props.children)
 		if (
 			prevProps.numberOfLines !== this.props.numberOfLines ||
-			// @TODO find better comparison for when children has changed
-			prevProps.children !== this.props.children
+			newText !== oldText
 		) {
 			this.setUpMeasurement()
 		}

--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -69,6 +69,16 @@ export class ExpandableText extends PureComponent<Props, State>
 		this.setUpMeasurement()
 	}
 
+	public componentDidUpdate(prevProps: Readonly<Props>): void {
+		if (
+			prevProps.numberOfLines !== this.props.numberOfLines ||
+			// @TODO find better comparison for when children has changed
+			prevProps.children !== this.props.children
+		) {
+			this.setUpMeasurement()
+		}
+	}
+
 	public componentWillUnmount(): void {
 		this.isTextMounted = false
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import { NativeComponent } from 'react-native'
 
 export function measureHeight(component: NativeComponent): Promise<number> {
@@ -8,4 +9,20 @@ export function measureHeight(component: NativeComponent): Promise<number> {
 
 export function nextFrameAsync(): Promise<void> {
 	return new Promise(resolve => requestAnimationFrame(() => resolve()))
+}
+
+export function extractTextFromReactNode(component: ReactNode): string {
+	if (!component) return ''
+
+	if (typeof component !== 'object') return String(component)
+
+	if (Array.isArray(component)) {
+		return component.map(extractTextFromReactNode).join(' ')
+	}
+
+	const child: ReactNode =
+		// @ts-ignore issue: https://stackoverflow.com/questions/54170961/ts2339-property-props-does-not-exist-on-type
+		component.children || (component.props && component.props.children)
+
+	return extractTextFromReactNode(child || '')
 }


### PR DESCRIPTION
When inner text changes, or when the number of lines do, we want to
calculate whether the text should still be collapsed or not.

When comparing children as a string it is easy to
check if it as changed or not, when using objects it becomes hard since
they might have the exact render data, but their object id change, thus
triggering a re-render.

So by extracting all text in the children nodes, and compare the text
now and before, we have a better idea of what as changed.
This doesn't cover style changes, as in font size or weight changes,
those can affect the height enough to change the component from static
to collapsible. I don't consider them relevant (at least for this stage).