### PR TITLE
Set lint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"typescript": "^3.2.2"
 	},
 	"peerDependencies": {
-		"react-native": "*"
+		"react": "^16",
+		"react-native": "^0.57"
 	},
 	"husky": {
 		"hooks": {

--- a/src/ExpandableText.tsx
+++ b/src/ExpandableText.tsx
@@ -17,8 +17,8 @@ interface ExpandableTextInterface {
 interface Props {
 	numberOfLines: number
 	children: string | Text
-	controller?: (ref: ExpandableTextInterface) => void
-	onReady?: (prop: { isCollapsible: boolean }) => void
+	controller?(ref: ExpandableTextInterface): void
+	onReady?(prop: { isCollapsible: boolean }): void
 }
 
 interface State {
@@ -96,7 +96,7 @@ export class ExpandableText extends PureComponent<Props, State>
 		)
 	}
 
-	private setUpMeasurement = async (): Promise<void> => {
+	private readonly setUpMeasurement = async (): Promise<void> => {
 		if (!this.text) throw Error('Text is not set to be measured')
 		const { numberOfLines } = this.props
 		await nextFrameAsync()
@@ -119,5 +119,5 @@ export class ExpandableText extends PureComponent<Props, State>
 		)
 	}
 
-	private setText = (ref: Text) => (this.text = ref)
+	private readonly setText = (ref: Text) => (this.text = ref)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,16 @@
 import { ReactNode } from 'react'
 import { NativeComponent } from 'react-native'
 
-export function measureHeight(component: NativeComponent): Promise<number> {
+export async function measureHeight(
+	component: NativeComponent,
+): Promise<number> {
 	return new Promise(resolve => {
 		component.measure((x, y, w, h) => resolve(h))
 	})
 }
 
-export function nextFrameAsync(): Promise<void> {
+export async function nextFrameAsync(): Promise<void> {
+	// tslint:disable-next-line no-unnecessary-callback-wrapper
 	return new Promise(resolve => requestAnimationFrame(() => resolve()))
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,310 @@
 		"tslint-config-prettier"
 	],
 	"rules": {
-		"curly": [true, "ignore-same-line"],
-		"interface-name": [true, "never-prefix"]
+		// @todo extract rules to own TS lint package
+		// TypeScript specific
+		"adjacent-overload-signatures": true,
+		"ban-types": true,
+		"member-access": true,
+		"member-ordering": [
+			true,
+			{
+				"order": [
+					"public-static-field",
+					"public-instance-field",
+					"private-static-field",
+					"private-instance-field",
+					"public-static-method",
+					"private-static-method",
+					"public-constructor",
+					"private-constructor",
+					"public-instance-method",
+					"protected-instance-method",
+					"private-instance-method"
+				]
+			}
+		],
+		"no-any": true,
+		"no-empty-interface": true,
+		"no-import-side-effect": true,
+		"no-inferrable-types": false,
+		"no-internal-module": true,
+		"no-magic-numbers": true,
+		"no-namespace": true,
+		"no-non-null-assertion": true,
+		"no-parameter-reassignment": true,
+		"no-reference": true,
+		"no-unnecessary-type-assertion": true,
+		"no-var-requires": true,
+		"only-arrow-functions": false,
+		"prefer-for-of": true,
+		"promise-function-async": true,
+		"typedef": true,
+		"typedef-whitespace": [
+			true,
+			{
+				"call-signature": "nospace",
+				"index-signature": "nospace",
+				"parameter": "nospace",
+				"property-declaration": "nospace",
+				"variable-declaration": "nospace"
+			},
+			{
+				"call-signature": "onespace",
+				"index-signature": "onespace",
+				"parameter": "onespace",
+				"property-declaration": "onespace",
+				"variable-declaration": "onespace"
+			}
+		],
+		"unified-signatures": true,
+
+		// Functionality
+		"await-promise": true,
+		"ban-comma-operator": true,
+		"curly": [
+			true,
+			"ignore-same-line"
+		],
+		"forin": true,
+		"function-constructor": true,
+		"label-position": true,
+		"no-arg": true,
+		"no-bitwise": true,
+		"no-conditional-assignment": false,
+		"no-console": true,
+		"no-construct": true,
+		"no-debugger": true,
+		"no-duplicate-super": true,
+		"no-duplicate-switch-case": true,
+		"no-duplicate-variable": true,
+		"no-dynamic-delete": true,
+		"no-empty": true,
+		"no-eval": true,
+		"no-floating-promises": false,
+		"no-for-in-array": false,
+		"no-implicit-dependencies": true,
+		"no-inferred-empty-object-type": true,
+		"no-invalid-template-strings": true,
+		"no-invalid-this": true,
+		"no-misused-new": true,
+		"no-null-keyword": true,
+		"no-object-literal-type-assertion": true,
+		"no-return-await": true,
+		"no-shadowed-variable": true,
+		"no-sparse-arrays": true,
+		"no-string-literal": true,
+		"no-string-throw": true,
+		"no-submodule-imports": true,
+		"no-switch-case-fall-through": true,
+		"no-this-assignment": [
+			true,
+			{
+				"allowed-names": [
+					"^self$"
+				]
+			}
+		],
+		"no-unbound-method": true,
+		"no-unnecessary-class": false,
+    // @todo discover why this fails src/utils.ts:27:35 - Unsafe use of expression of type 'any'.
+		"no-unsafe-any": false,
+		"no-unsafe-finally": true,
+		"no-unused-expression": true,
+		"no-use-before-declare": true,
+		"no-var-keyword": true,
+		"no-void-expression": [
+			true,
+			"ignore-arrow-function-shorthand"
+		],
+		"prefer-conditional-expression": true,
+		"prefer-object-spread": false,
+		"radix": true,
+		"restrict-plus-operands": true,
+		"strict-boolean-expressions": false,
+		"strict-type-predicates": true,
+		"switch-default": false,
+		"triple-equals": true,
+		"unnecessary-constructor": true,
+		"use-default-type-parameter": true,
+		"use-isnan": true,
+
+    // Maintainability
+		"cyclomatic-complexity": [
+			true,
+			10
+		],
+		"deprecation": true,
+		"eofline": true,
+		"indent": [
+			true,
+			"tabs"
+		],
+		"linebreak-style": [
+			true,
+			"LF"
+		],
+		"max-classes-per-file": [
+			true,
+			1
+		],
+		"max-file-line-count": [
+			true,
+			300
+		],
+		"max-line-length": [
+			true,
+			80
+		],
+		"no-default-export": true,
+		"no-default-import": false,
+		"no-duplicate-imports": true,
+		"no-mergeable-namespace": true,
+		"no-require-imports": true,
+		"object-literal-sort-keys": [
+			true,
+			"ignore-case"
+		],
+		"prefer-const": true,
+		"prefer-readonly": true,
+		"trailing-comma": [
+			true,
+			{
+				"esSpecCompliant": true
+			}
+		],
+
+		// Style
+		"align": [
+			true,
+			"arguments",
+			"elements",
+			"members",
+			"parameters",
+			"statements"
+		],
+		"array-type": [
+			true,
+			"generic"
+		],
+		"arrow-parens": false,
+		"arrow-return-shorthand": true,
+		"binary-expression-operand-order": true,
+		"callable-types": true,
+		"class-name": true,
+		"comment-format": [
+			true,
+			"check-space",
+			"check-lowercase"
+		],
+		"comment-type": [
+			true,
+			"singleline",
+			"doc"
+		],
+		"completed-docs": false,
+		"encoding": true,
+		"file-header": false,
+		"file-name-casing": [
+			true,
+			{
+				".tsx": "pascal-case",
+				".*": "camel-case"
+			}
+		],
+		"import-spacing": true,
+		"increment-decrement": false,
+		"interface-name": [
+			true,
+			"never-prefix"
+		],
+		"interface-over-type-literal": true,
+		"jsdoc-format": true,
+		"match-default-export-name": true,
+		"newline-before-return": true,
+		"newline-per-chained-call": false,
+		"new-parens": true,
+		"no-angle-bracket-type-assertion": true,
+		"no-boolean-literal-compare": true,
+		"no-consecutive-blank-lines": true,
+		"no-irregular-whitespace": true,
+		"no-parameter-properties": true,
+		"no-redundant-jsdoc": true,
+		"no-reference-import": true,
+		"no-trailing-whitespace": true,
+		"no-unnecessary-callback-wrapper": true,
+		"no-unnecessary-initializer": true,
+		"no-unnecessary-qualifier": true,
+		"number-literal-format": true,
+		"object-literal-key-quotes": [
+			true,
+			"as-needed"
+		],
+		"object-literal-shorthand": true,
+		"one-line": true,
+		"one-variable-per-declaration": [
+			true,
+			"ignore-for-loop"
+		],
+		"ordered-imports": true,
+		"prefer-function-over-method": false,
+		"prefer-method-signature": true,
+		"prefer-switch": [
+			true,
+			{
+				"min-cases": 3
+			}
+		],
+		"prefer-template": [
+			true,
+			"allow-single-concat"
+		],
+		"prefer-while": true,
+		"quotemark": [
+			true,
+			"single",
+			"avoid-escape",
+			"avoid-template"
+		],
+		"return-undefined": true,
+		"semicolon": [
+			true,
+			"never"
+		],
+		"space-before-function-paren": [
+			true,
+			{
+				"anonymous": "always",
+				"asyncArrow": "always",
+				"constructor": "never",
+				"method": "never",
+				"named": "never"
+			}
+		],
+		"space-within-parens": false,
+		"switch-final-break": [
+			true,
+			"always"
+		],
+		"type-literal-delimiter": false,
+		"unnecessary-bind": true,
+		"variable-name": [
+			true,
+			"ban-keywords",
+			"check-format"
+		],
+		"whitespace": [
+			true,
+			"check-branch",
+			"check-decl",
+			"check-operator",
+			"check-module",
+			"check-separator",
+			"check-rest-spread",
+			"check-type",
+			"check-typecast",
+			"check-type-operator",
+			"check-preblock"
+		]
 	}
 }


### PR DESCRIPTION
To ensure the code looks the same across the full project, I prefer to
be strict about the rules.

Since TSLint fixes most of the style issues automatically and many
others the Prettier take care of them, dev's only have to focus on
ensuring code quality.